### PR TITLE
fix: use the hash specific syntax

### DIFF
--- a/lib/yard-sig/sig.rb
+++ b/lib/yard-sig/sig.rb
@@ -50,7 +50,7 @@ module YardSig
       if kind == :rest
         yard_types = "Array<#{yard_types}>"
       elsif kind == :keyrest
-        yard_types = "Hash<Symbol, #{yard_types}>"
+        yard_types = "Hash{Symbol => #{yard_types}}"
       end
 
       YARD::Tags::Tag.new(tag_name, "", yard_types, name)
@@ -82,8 +82,14 @@ module YardSig
       when RBS::Types::Bases::Instance
         @namespace.to_s
       when RBS::Types::ClassInstance
-        args = type.args.map { |t| to_yard_type(t) }.join(", ")
-        args.empty? ? type.to_s : "#{type.name}<#{args}>"
+        args = type.args.map { |t| to_yard_type(t) }
+        if args.empty?
+          type.to_s
+        elsif type.name.name == :Hash
+          "#{type.name}{#{args[0]} => #{args[1]}}"
+        else
+          "#{type.name}<#{args.join(", ")}>"
+        end
       else
         type.to_s
       end

--- a/spec/yard-sig/sig_spec.rb
+++ b/spec/yard-sig/sig_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe YardSig::Sig do
     it "returns a param tag for the keyrest parameter" do
       sig = described_class.new("(**Integer opts) -> void")
       expect(sig.to_tags).to eq_tags([
-        tag(:param, "", ["Hash<Symbol, Integer>"], "opts")
+        tag(:param, "", ["Hash{Symbol => Integer}"], "opts")
       ])
     end
 
@@ -60,7 +60,7 @@ RSpec.describe YardSig::Sig do
       expect(sig.to_tags).to eq_tags([
         tag(:yieldparam, "", ["Integer"], "a"),
         tag(:yieldparam, "", ["Array<Integer>"], "b"),
-        tag(:yieldparam, "", ["Hash<Symbol, Integer>"], "c"),
+        tag(:yieldparam, "", ["Hash{Symbol => Integer}"], "c"),
         tag(:yieldreturn, "", ["String"])
       ])
     end
@@ -72,10 +72,31 @@ RSpec.describe YardSig::Sig do
       ])
     end
 
-    it "returns a param tag with generics" do
+    it "returns a param tag that is an array with generics" do
       sig = described_class.new("(Array[Integer] a) -> void")
       expect(sig.to_tags).to eq_tags([
         tag(:param, "", ["Array<Integer>"], "a")
+      ])
+    end
+
+    it "returns a param tag that is an array with multiple generics" do
+      sig = described_class.new("(Array[Integer|String] a) -> void")
+      expect(sig.to_tags).to eq_tags([
+        tag(:param, "", ["Array<Integer, String>"], "a")
+      ])
+    end
+
+    it "returns a param tag that is a hash with generics" do
+      sig = described_class.new("(Hash[String, Integer] a) -> void")
+      expect(sig.to_tags).to eq_tags([
+        tag(:param, "", ["Hash{String => Integer}"], "a")
+      ])
+    end
+
+    it "returns a param tag that is a hash with multiple generics" do
+      sig = described_class.new("(Hash[String, Integer|String] a) -> void")
+      expect(sig.to_tags).to eq_tags([
+        tag(:param, "", ["Hash{String => Integer, String}"], "a")
       ])
     end
 
@@ -130,7 +151,7 @@ RSpec.describe YardSig::Sig do
       expect(sig.to_tags).to eq_tags([
         tag(:param, "", ["Integer"], "a"),
         tag(:param, "", ["Array<Symbol>"], "b"),
-        tag(:param, "", ["Hash<Symbol, String>"], "c")
+        tag(:param, "", ["Hash{Symbol => String}"], "c")
       ])
     end
   end


### PR DESCRIPTION
The `Hash<KeyType, ValueType>` syntax does not allow you to specify
multiple types for keys and values.
It changes to the hash specific syntax to fix this issue.

refs: https://github.com/lsegal/yard/blob/v0.9.34/docs/Tags.md#hashes
