### PR TITLE
fix: support optional types

### DIFF
--- a/lib/yard-sig/sig.rb
+++ b/lib/yard-sig/sig.rb
@@ -81,6 +81,8 @@ module YardSig
         "Boolean"
       when RBS::Types::Bases::Instance
         @namespace.to_s
+      when RBS::Types::Optional
+        "#{to_yard_type(type.type)}, nil"
       when RBS::Types::ClassInstance
         args = type.args.map { |t| to_yard_type(t) }
         if args.empty?

--- a/spec/yard-sig/sig_spec.rb
+++ b/spec/yard-sig/sig_spec.rb
@@ -16,10 +16,24 @@ RSpec.describe YardSig::Sig do
       ])
     end
 
+    it "returns a param tag for optional parameter with optional type" do
+      sig = described_class.new("(?Integer? a) -> void")
+      expect(sig.to_tags).to eq_tags([
+        tag(:param, "", ["Integer, nil"], "a")
+      ])
+    end
+
     it "returns a return tag" do
       sig = described_class.new("() -> Integer")
       expect(sig.to_tags).to eq_tags([
         tag(:return, "", ["Integer"])
+      ])
+    end
+
+    it "returns a return tag for optional type" do
+      sig = described_class.new("() -> Integer?")
+      expect(sig.to_tags).to eq_tags([
+        tag(:return, "", ["Integer, nil"])
       ])
     end
 


### PR DESCRIPTION
When specifying a value like `Integer?` in an optional type,
`Integer?` was output as is in the YARD type definition.

This commit fixes the type definition to output Integer and nil.
