### PR TITLE
ci: CI against ruby 3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - '3.3'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.2.2'
+          - '3.2'
+          - '3.3'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Ruby 3.3 has already been released, so add it to CI.
Also upgrade actions/checkout.