### PR TITLE
fix: fix invalid tags when specifying multiple types

### DIFF
--- a/lib/yard-sig/sig.rb
+++ b/lib/yard-sig/sig.rb
@@ -52,9 +52,9 @@ module YardSig
       name = type.name ? type.name.to_s : find_name_from_yard(kind, pos)
 
       if kind == :rest
-        yard_types = "Array<#{yard_types}>"
+        yard_types = "Array<#{yard_types.join(", ")}>"
       elsif kind == :keyrest
-        yard_types = "Hash{Symbol => #{yard_types}}"
+        yard_types = "Hash{Symbol => #{yard_types.join(", ")}}"
       end
 
       YARD::Tags::Tag.new(tag_name, "", yard_types, name)
@@ -82,29 +82,31 @@ module YardSig
       when RBS::Types::Bases::Void, RBS::Types::Bases::Any, RBS::Types::Bases::Bottom
         nil
       when RBS::Types::Bases::Top
-        "Object"
+        ["Object"]
       when RBS::Types::Union
-        type.types.map { |t| to_yard_type(t) }.join(", ")
+        type.types.map { |t| to_yard_type(t) }
       when RBS::Types::Tuple
         args = type.types.map { |t| to_yard_type(t) }.join(", ")
-        "Array[#{args}]"
+        ["Array[#{args}]"]
       when RBS::Types::Bases::Bool
-        "Boolean"
+        ["Boolean"]
       when RBS::Types::Bases::Instance
-        @namespace.to_s
+        [@namespace.to_s]
       when RBS::Types::Optional
-        "#{to_yard_type(type.type)}, nil"
+        [to_yard_type(type.type).join(", ").to_s, "nil"]
       when RBS::Types::ClassInstance
         args = type.args.map { |t| to_yard_type(t) }
         if args.empty?
-          type.to_s
+          [type.to_s]
         elsif type.name.name == :Hash
-          "#{type.name}{#{args[0]} => #{args[1]}}"
+          key = args[0].join(", ")
+          value = args[1].join(", ")
+          ["#{type.name}{#{key} => #{value}}"]
         else
-          "#{type.name}<#{args.join(", ")}>"
+          ["#{type.name}<#{args.join(", ")}>"]
         end
       else
-        type.to_s
+        [type.to_s]
       end
     end
 

--- a/spec/yard-sig/sig_spec.rb
+++ b/spec/yard-sig/sig_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe YardSig::Sig do
     it "returns a param tag for optional parameter with optional type" do
       sig = described_class.new("(?Integer? a) -> void")
       expect(sig.to_tags).to eq_tags([
-        tag(:param, "", ["Integer, nil"], "a")
+        tag(:param, "", %w[Integer nil], "a")
       ])
     end
 
@@ -33,7 +33,7 @@ RSpec.describe YardSig::Sig do
     it "returns a return tag for optional type" do
       sig = described_class.new("() -> Integer?")
       expect(sig.to_tags).to eq_tags([
-        tag(:return, "", ["Integer, nil"])
+        tag(:return, "", %w[Integer nil])
       ])
     end
 
@@ -90,7 +90,7 @@ RSpec.describe YardSig::Sig do
     it "returns a param tag with multiple types" do
       sig = described_class.new("(Integer | String a) -> void")
       expect(sig.to_tags).to eq_tags([
-        tag(:param, "", ["Integer, String"], "a")
+        tag(:param, "", %w[Integer String], "a")
       ])
     end
 


### PR DESCRIPTION
When union type and optional type were specified, the class name
contained commas.

This means that when `Integer?` was specified, it was treated as the
type "Integer, nil".
It should correctly be treated as tyow types, "Integer" and "nil".
